### PR TITLE
Specifying requirements and fixing imports

### DIFF
--- a/experiments/mbcd_run.py
+++ b/experiments/mbcd_run.py
@@ -2,7 +2,7 @@ import os
 import gym
 import numpy as np
 import pandas as pd
-import random 
+import random
 import argparse
 
 import tensorflow as tf

--- a/mbcd/models/constructor.py
+++ b/mbcd/models/constructor.py
@@ -1,8 +1,8 @@
 import numpy as np
 import tensorflow as tf
 
-from drl_cd.models.fc import FC
-from drl_cd.models.bnn import BNN
+from mbcd.models.fc import FC
+from mbcd.models.bnn import BNN
 
 def construct_model(name, obs_dim=11, act_dim=3, rew_dim=1, hidden_dim=200, num_networks=7, num_elites=5, session=None):
 	print('[ BNN ] Observation dim {} | Action dim: {} | Hidden dim: {}'.format(obs_dim, act_dim, hidden_dim))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 from setuptools import setup, find_packages
 
-REQUIRED = ['numpy', 'pandas', 'matplotlib', 'stable-baselines']
+REQUIRED = ['numpy',
+            'pandas',
+            'matplotlib',
+            'stable-baselines',
+            'gym<0.20',
+            'tensorflow<2.0',
+            'tqdm',
+            'cpython<3.0']
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Since stable-baselines3 is out now, it was hard retrofitting an environment around stable-baselines. I didn't want to anchor down the whole of the requirements but I think the couple I've changed are necessary for the code to work as written.

I also changed an import that I believe was misnamed. With this change it works on my machine.